### PR TITLE
Error when fitting with CUDA not functional (adding conditional to fix)

### DIFF
--- a/experiments/Project.toml
+++ b/experiments/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
+NeuroTreeModels = "1db4e0a5-a364-4b0c-897c-2bd5a4a3a1f2"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/experiments/classification.jl
+++ b/experiments/classification.jl
@@ -1,0 +1,40 @@
+using NeuroTreeModels
+using MLDatasets
+using DataFrames
+using Statistics: mean
+using CategoricalArrays
+using Random
+Random.seed!(123)
+
+df = MLDatasets.Iris().dataframe
+
+df[!, :class] = categorical(df[!, :class])
+df[!, :class] .= levelcode.(df[!, :class])
+target_name = "class"
+feature_names = setdiff(names(df), [target_name])
+
+train_ratio = 0.8
+train_indices = randperm(nrow(df))[1:Int(train_ratio * nrow(df))]
+
+dtrain = df[train_indices, :]
+deval = df[setdiff(1:nrow(df), train_indices), :]
+
+config = NeuroTreeRegressor(
+    device=:cpu,
+    loss=:mlogloss,
+    nrounds=400,
+    outsize=3,
+    depth=4,
+    lr=2e-2,
+)
+
+m = NeuroTreeModels.fit(
+    config,
+    dtrain;
+    deval,
+    target_name,
+    feature_names,
+    metric=:mlogloss,
+    print_every_n=10,
+    early_stopping_rounds=2,
+)

--- a/experiments/classification.jl
+++ b/experiments/classification.jl
@@ -39,6 +39,5 @@ m = NeuroTreeModels.fit(
     early_stopping_rounds=2,
 )
 
-# Predictions depend on the number of samples in the dataset
 m(dtrain[1:5, :])[1:1,:] 
 m(dtrain[1:1, :])[1:1,:]

--- a/experiments/classification.jl
+++ b/experiments/classification.jl
@@ -38,3 +38,7 @@ m = NeuroTreeModels.fit(
     print_every_n=10,
     early_stopping_rounds=2,
 )
+
+# Predictions depend on the number of samples in the dataset
+m(dtrain[1:5, :])[1:1,:] 
+m(dtrain[1:1, :])[1:1,:]

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -146,7 +146,9 @@ end
 function fit_iter!(m, cache)
     loss, opts, data = cache[:loss], cache[:opts], cache[:dtrain]
     GC.gc(true)
-    CUDA.reclaim()
+    if m.info[:device] == :gpu
+        CUDA.reclaim()
+    end
     for d in data
         grads = gradient(model -> loss(model, d...), m)[1]
         Optimisers.update!(opts, m, grads)

--- a/src/infer.jl
+++ b/src/infer.jl
@@ -41,7 +41,7 @@ function infer(m::NeuroTreeModel{<:MLogLoss}, data::DL)
         push!(preds, Matrix(m(x)'))
     end
     p = vcat(preds...)
-    softmax!(p; dims=1)
+    softmax!(p; dims=2)
     return p
 end
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -70,21 +70,21 @@ end
     mlogloss(x, y, w, offset; agg=mean)
 """
 function mlogloss(m, x, y; agg=mean)
-    p = logsoftmax(m(x); dims=2)
+    p = logsoftmax(m(x); dims=1)
     k = size(p, 1)
     raw = dropdims(-sum(onehotbatch(y, 1:k) .* p; dims=1); dims=1)
     metric = agg(raw)
     return metric
 end
 function mlogloss(m, x, y, w; agg=mean)
-    p = logsoftmax(m(x); dims=2)
+    p = logsoftmax(m(x); dims=1)
     k = size(p, 1)
     raw = dropdims(-sum(onehotbatch(y, 1:k) .* p; dims=1); dims=1)
     metric = agg(raw .* w)
     return metric
 end
 function mlogloss(m, x, y, w, offset; agg=mean)
-    p = logsoftmax(m(x) .+ offset; dims=2)
+    p = logsoftmax(m(x) .+ offset; dims=1)
     k = size(p, 1)
     raw = dropdims(-sum(onehotbatch(y, 1:k) .* p; dims=1); dims=1)
     metric = agg(raw .* w)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -70,21 +70,21 @@ end
     mlogloss(x, y, w, offset; agg=mean)
 """
 function mlogloss(m, x, y; agg=mean)
-    p = logsoftmax(m(x); dims=1)
+    p = logsoftmax(m(x); dims=2)
     k = size(p, 1)
     raw = dropdims(-sum(onehotbatch(y, 1:k) .* p; dims=1); dims=1)
     metric = agg(raw)
     return metric
 end
 function mlogloss(m, x, y, w; agg=mean)
-    p = logsoftmax(m(x); dims=1)
+    p = logsoftmax(m(x); dims=2)
     k = size(p, 1)
     raw = dropdims(-sum(onehotbatch(y, 1:k) .* p; dims=1); dims=1)
     metric = agg(raw .* w)
     return metric
 end
 function mlogloss(m, x, y, w, offset; agg=mean)
-    p = logsoftmax(m(x) .+ offset; dims=1)
+    p = logsoftmax(m(x) .+ offset; dims=2)
     k = size(p, 1)
     raw = dropdims(-sum(onehotbatch(y, 1:k) .* p; dims=1); dims=1)
     metric = agg(raw .* w)


### PR DESCRIPTION
Finally having a first go at adding an extension to [CounterfactualExplanations.jl](https://github.com/JuliaTrustworthyAI/CounterfactualExplanations.jl/pull/427) and noticed that trying to fit a model when CUDA is not functional throws an error:

```julia-repl
julia> using CounterfactualExplanations
       using MLJBase
       using NeuroTreeModels
       using TaijaData
       
       m = NeuroTreeRegressor(; depth=5, nrounds=10)
       X, y = @load_boston
       mach = machine(m, X, y) 
       MLJBase.fit!(mach)
┌ Warning: Package cuDNN not found in current path.
│ - Run `import Pkg; Pkg.add("cuDNN")` to install the cuDNN package, then restart julia.
│ - If cuDNN is not installed, some Flux functionalities will not be available when running on the GPU.
└ @ FluxCUDAExt ~/.julia/packages/Flux/Wz6D4/ext/FluxCUDAExt/FluxCUDAExt.jl:57
[ Info: Precompiling NeuroTreeModels [1db4e0a5-a364-4b0c-897c-2bd5a4a3a1f2]
┌ Warning: Package cuDNN not found in current path.
│ - Run `import Pkg; Pkg.add("cuDNN")` to install the cuDNN package, then restart julia.
│ - If cuDNN is not installed, some Flux functionalities will not be available when running on the GPU.
└ @ FluxCUDAExt ~/.julia/packages/Flux/Wz6D4/ext/FluxCUDAExt/FluxCUDAExt.jl:57
WARNING: Method definition supports_weights(Type{var"#s27"} where var"#s27"<:NeuroTreeModels.NeuroTreeRegressor) in module NeuroTreeModels at /Users/paltmeyer/.julia/packages/NeuroTreeModels/DXITM/src/MLJ.jl:71 overwritten at /Users/paltmeyer/.julia/packages/MLJModelInterface/ihpHk/src/metadata_utils.jl:62.
ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
[ Info: Skipping precompilation since __precompile__(false). Importing NeuroTreeModels [1db4e0a5-a364-4b0c-897c-2bd5a4a3a1f2].
[ Info: Precompiling NeuroTreeExt [3b9b29e0-2f41-503c-9947-dc8035483bb2]
┌ Warning: Package cuDNN not found in current path.
│ - Run `import Pkg; Pkg.add("cuDNN")` to install the cuDNN package, then restart julia.
│ - If cuDNN is not installed, some Flux functionalities will not be available when running on the GPU.
└ @ FluxCUDAExt ~/.julia/packages/Flux/Wz6D4/ext/FluxCUDAExt/FluxCUDAExt.jl:57
┌ Warning: Module NeuroTreeModels with build ID ffffffff-ffff-ffff-0001-d43218202e04 is missing from the cache.
│ This may mean NeuroTreeModels [1db4e0a5-a364-4b0c-897c-2bd5a4a3a1f2] does not support precompilation but is imported by a module that does.
└ @ Base loading.jl:1948
[ Info: Skipping precompilation since __precompile__(false). Importing NeuroTreeExt [3b9b29e0-2f41-503c-9947-dc8035483bb2].
[ Info: Following 14 arguments were not provided and will be set to default: batchsize, MLE_tree_split, gpuID, ntrees, hidden_size, wd, actA, loss, rng, init_scale, device, outsize, lr, stack_size.
[ Info: Training machine(NeuroTreeRegressor(loss = mse, …), …).
[ Info: ["Crim", "Zn", "Indus", "NOx", "Rm", "Age", "Dis", "Rad", "Tax", "PTRatio", "Black", "LStat"]
┌ Error: Problem fitting the machine machine(NeuroTreeRegressor(loss = mse, …), …). 
└ @ MLJBase ~/.julia/packages/MLJBase/iIhiI/src/machines.jl:683
[ Info: Running type checks... 
[ Info: Type checks okay. 
ERROR: CUDA driver not found
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] functional
    @ ~/.julia/packages/CUDA/htRwP/src/initialization.jl:24 [inlined]
  [3] task_local_state!()
    @ CUDA ~/.julia/packages/CUDA/htRwP/lib/cudadrv/state.jl:77
  [4] device
    @ ~/.julia/packages/CUDA/htRwP/lib/cudadrv/state.jl:191 [inlined]
  [5] reclaim(sz::Int64)
    @ CUDA ~/.julia/packages/CUDA/htRwP/src/pool.jl:532
  [6] reclaim
    @ ~/.julia/packages/CUDA/htRwP/src/pool.jl:532 [inlined]
  [7] fit_iter!(m::NeuroTreeModels.NeuroTreeModel{…}, cache::@NamedTuple{…})
    @ NeuroTreeModels ~/.julia/packages/NeuroTreeModels/DXITM/src/fit.jl:149
  [8] fit(model::NeuroTreeRegressor, verbosity::Int64, A::@NamedTuple{…}, y::SubArray{…}, w::Nothing)
    @ NeuroTreeModels ~/.julia/packages/NeuroTreeModels/DXITM/src/MLJ.jl:28
  [9] fit(model::NeuroTreeRegressor, verbosity::Int64, A::@NamedTuple{…}, y::SubArray{…})
    @ NeuroTreeModels ~/.julia/packages/NeuroTreeModels/DXITM/src/MLJ.jl:8
 [10] fit_only!(mach::Machine{NeuroTreeRegressor, true}; rows::Nothing, verbosity::Int64, force::Bool, composite::Nothing)
    @ MLJBase ~/.julia/packages/MLJBase/iIhiI/src/machines.jl:681
 [11] fit_only!
    @ ~/.julia/packages/MLJBase/iIhiI/src/machines.jl:607 [inlined]
 [12] #fit!#63
    @ ~/.julia/packages/MLJBase/iIhiI/src/machines.jl:778 [inlined]
 [13] fit!(mach::Machine{NeuroTreeRegressor, true})
    @ MLJBase ~/.julia/packages/MLJBase/iIhiI/src/machines.jl:775
 [14] top-level scope
    @ ~/code/CounterfactualExplanations.jl/test/models/neurotree.jl:9
Some type information was truncated. Use `show(err)` to see complete types.
```

This PR just adds a conditional statement to avoid this error.

